### PR TITLE
feat: :sparkles: ignore `.DS_Store` and `.quarto` files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
     usethis functions, so it is added to the created `DESCRIPTION` file
     (#137).
 - When creating a new `.gitignore`, include `.quarto` and `.DS_Store`
-    files (#140).
+    files (#141).
 
 # prodigenr 0.6.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - The `title` field in the `DESCRIPTION` file is needed by many
     usethis functions, so it is added to the created `DESCRIPTION` file
     (#137).
+- When creating a new `.gitignore`, include `.quarto` and `.DS_Store`
+    files (#140).
 
 # prodigenr 0.6.2
 

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -83,8 +83,10 @@ setup_with_git <- function() {
 # Utilities -----------------------------------------------------
 
 set_git_ignore_files <- function() {
-    base::writeLines(c(".Rhistory", ".RData", ".Rproj.user"),
-                     ".gitignore")
+  base::writeLines(
+    c(".Rhistory", ".RData", ".Rproj.user", ".DS_Store", ".quarto"),
+    ".gitignore"
+  )
 }
 
 path_remove_spaces <- function(path) {


### PR DESCRIPTION
## Description

It's nice to automatically ignore MacOS created files `.DS_Store` as well as the `.quarto` folder.

Closes #136
