### PR TITLE
feat: :sparkles: remove report creation from project setup function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
     (#137).
 - When creating a new `.gitignore`, include `.quarto` and `.DS_Store`
     files (#141).
+- It isn't always useful to have the report created when the project
+    is setup, so adding the report via `create_report()` is removed from
+    `project_setup()` (#142).
 
 # prodigenr 0.6.2
 

--- a/R/create_doc.R
+++ b/R/create_doc.R
@@ -1,4 +1,3 @@
-
 #' Create a basic R Markdown document from a template.
 #'
 #' Creates manuscript/report or slide R Markdown file and saves it into
@@ -15,35 +14,37 @@
 #' create_slides()
 #' }
 create_doc <- function(type = c("report", "slides")) {
-    if (!is_rproj_folder())
-        rlang::abort("The folder does not contain an `.Rproj` file. Please use this function while in the project created from `setup_project().`")
+  if (!is_rproj_folder()) {
+    rlang::abort("The folder does not contain an `.Rproj` file. Please use this function while in the project created from `setup_project().`")
+  }
 
-    if (!dir.exists("doc"))
-        rlang::abort("What happened to your `doc/` folder?")
+  if (!dir.exists("doc")) {
+    rlang::abort("What happened to your `doc/` folder?")
+  }
 
-    type <- match.arg(type)
-    file_name <- normalizePath(file.path("doc", paste0(type, ".Rmd")), mustWork = FALSE)
-    template_file <- fs::path_package("prodigenr", "rmarkdown", "templates", type)
-    if (fs::file_exists(file_name)) {
-        rlang::abort(paste0("The file '", type, ".Rmd' already exists in the doc folder."))
-    } else {
-        rmarkdown::draft(
-            file = file_name,
-            template = template_file,
-            package = NULL,
-            create_dir = FALSE,
-            edit = FALSE
-        )
-        cli::cli_alert_success("Creating a {.val {type}} file in the {.val {'doc/'}} folder.")
-    }
-    invisible()
+  type <- match.arg(type)
+  file_name <- normalizePath(file.path("doc", paste0(type, ".Rmd")), mustWork = FALSE)
+  template_file <- fs::path_package("prodigenr", "rmarkdown", "templates", type)
+  if (fs::file_exists(file_name)) {
+    rlang::abort(paste0("The file '", type, ".Rmd' already exists in the doc folder."))
+  } else {
+    rmarkdown::draft(
+      file = file_name,
+      template = template_file,
+      package = NULL,
+      create_dir = FALSE,
+      edit = FALSE
+    )
+    cli::cli_alert_success("Creating a {.val {type}} file in the {.val {'doc/'}} folder.")
+  }
+  invisible()
 }
 
 #' @describeIn create_doc Creates a report R Markdown document in the `doc/` folder.
 #' @export
 create_report <- function() {
-    create_doc(type = "report")
-    return(invisible())
+  create_doc(type = "report")
+  return(invisible())
 }
 
 #' @describeIn create_doc Creates a manuscript R Markdown document in
@@ -54,7 +55,7 @@ create_manuscript <- create_report
 #' @describeIn create_doc Creates a R Markdown document for making slides in the `doc/` folder.
 #' @export
 create_slides <- function() {
-    create_doc(type = "slides")
+  create_doc(type = "slides")
 }
 
 #' List project templates within \pkg{prodigenr}.

--- a/R/rstudio_setup.R
+++ b/R/rstudio_setup.R
@@ -1,6 +1,5 @@
-
 rstudio_setup <- function(path, ...) {
-    # create project
-    setup_project(path = path)
-    invisible(NULL)
+  # create project
+  setup_project(path = path)
+  invisible(NULL)
 }

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -41,8 +41,7 @@ setup_project <-
                 update_template("template-Rproj", paste0(proj_name, ".Rproj"))
                 fs::file_delete("template-Rproj")
                 update_template("README.md", data = list(ProjectName = proj_name))
-                suppressMessages(create_report())
-            })
+
     }
 
 # Git setup functions -------------------------------------------

--- a/R/usethis-utils.R
+++ b/R/usethis-utils.R
@@ -27,25 +27,27 @@
 update_template <- function(template,
                             save_as = template,
                             data = list()) {
-    template_contents <-
-        base::strsplit(whisker::whisker.render(read_utf8(template),
-                                               data), "\n")[[1]]
-    new <- base::writeLines(template_contents, save_as)
-    invisible(new)
+  template_contents <-
+    base::strsplit(whisker::whisker.render(
+      read_utf8(template),
+      data
+    ), "\n")[[1]]
+  new <- base::writeLines(template_contents, save_as)
+  invisible(new)
 }
 
 # Taken from usethis package and modified to this package.
 find_template <- function(...) {
-    fs::path_package(package = "prodigenr", "templates", ...)
+  fs::path_package(package = "prodigenr", "templates", ...)
 }
 
 # Taken from usethis package
 read_utf8 <- function(path, n = -1L) {
-    base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
+  base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
 }
 
 # Taken from usethis:::uses_git
 has_git <- function(project_path = ".") {
-    repo <- tryCatch(gert::git_find(project_path), error = function(e) NULL)
-    !is.null(repo)
+  repo <- tryCatch(gert::git_find(project_path), error = function(e) NULL)
+  !is.null(repo)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,9 @@
 is_rproj_folder <- function() {
-    rprojroot::is.root_criterion(rprojroot::is_rstudio_project)
+  rprojroot::is.root_criterion(rprojroot::is_rstudio_project)
 }
 
 viz_project_tree <- function(path) {
-    withr::with_dir(fs::path_dir(path),
-                    {fs::dir_tree(basename(path), all = TRUE)})
+  withr::with_dir(fs::path_dir(path), {
+    fs::dir_tree(basename(path), all = TRUE)
+  })
 }

--- a/tests/testthat/test-files.R
+++ b/tests/testthat/test-files.R
@@ -4,17 +4,17 @@ new_project <- fs::path_temp("testing-docs")
 setup_project(new_project)
 
 test_that("Report and slides created", {
-    withr::with_dir(new = new_project, {
-        capture_output(create_slides())
-    })
+  withr::with_dir(new = new_project, {
+    capture_output(create_slides())
+  })
 
-    withr::with_dir(new = file.path(new_project, "doc"), {
-        expect_true(fs::file_exists("slides.Rmd"))
-        # Needs a Rproj file.
-        fs::file_delete("../testing-docs.Rproj")
-        fs::file_delete("slides.Rmd")
-        expect_error(create_slides())
-    })
+  withr::with_dir(new = file.path(new_project, "doc"), {
+    expect_true(fs::file_exists("slides.Rmd"))
+    # Needs a Rproj file.
+    fs::file_delete("../testing-docs.Rproj")
+    fs::file_delete("slides.Rmd")
+    expect_error(create_slides())
+  })
 })
 
 fs::dir_delete(new_project)

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -1,4 +1,4 @@
-context('Project creation and setup.')
+context("Project creation and setup.")
 
 new_project <- fs::path_temp("testing")
 setup_project(new_project)
@@ -6,34 +6,36 @@ setup_project(new_project)
 # project creation --------------------------------------------------------
 
 test_that("project is set up", {
-    expect_true(fs::dir_exists(new_project))
+  expect_true(fs::dir_exists(new_project))
 
-    files_created <- fs::dir_ls(new_project, recurse = TRUE)
-    folders_created <- fs::dir_ls(new_project, type = "directory")
-    expect_equal(sort(basename(folders_created)),
-                 sort(c("R", "doc", "data", "data-raw")))
+  files_created <- fs::dir_ls(new_project, recurse = TRUE)
+  folders_created <- fs::dir_ls(new_project, type = "directory")
+  expect_equal(
+    sort(basename(folders_created)),
+    sort(c("R", "doc", "data", "data-raw"))
+  )
 
-    expect_match(files_created, ".*DESCRIPTION$", all = FALSE)
-    expect_match(files_created, ".*testing\\.Rproj$", all = FALSE)
+  expect_match(files_created, ".*DESCRIPTION$", all = FALSE)
+  expect_match(files_created, ".*testing\\.Rproj$", all = FALSE)
 })
 
 test_that("git gets added", {
-    withr::with_dir(new = new_project, {
-        capture_output(setup_with_git())
-        git_files <- fs::dir_ls(new_project, all = TRUE)
-        expect_match(git_files, ".*\\.git$", all = FALSE)
-        expect_match(git_files, ".*\\.gitignore$", all = FALSE)
-    })
+  withr::with_dir(new = new_project, {
+    capture_output(setup_with_git())
+    git_files <- fs::dir_ls(new_project, all = TRUE)
+    expect_match(git_files, ".*\\.git$", all = FALSE)
+    expect_match(git_files, ".*\\.gitignore$", all = FALSE)
+  })
 })
 
 fs::dir_delete(new_project)
 
 test_that("project checks work correctly", {
-    expect_error(setup_project(1))
+  expect_error(setup_project(1))
 
-    temp_dir <- tempdir()
-    proj_with_space <- fs::file_temp("test new", tmp_dir = temp_dir)
-    expect_warning(setup_project(proj_with_space))
-    expect_true(fs::file_exists(sub("test new", "test-new", proj_with_space)))
-    fs::dir_delete(sub("test new", "test-new", proj_with_space))
+  temp_dir <- tempdir()
+  proj_with_space <- fs::file_temp("test new", tmp_dir = temp_dir)
+  expect_warning(setup_project(proj_with_space))
+  expect_true(fs::file_exists(sub("test new", "test-new", proj_with_space)))
+  fs::dir_delete(sub("test new", "test-new", proj_with_space))
 })

--- a/vignettes/prodigenr.Rmd
+++ b/vignettes/prodigenr.Rmd
@@ -75,10 +75,10 @@ create_slides()
 ```{r example-create-functions-hide, echo=FALSE}
 # you need to run these in the project's console
 withr::with_dir(
-    new = new_project_path,
-    code = {
-        create_slides()
-    }
+  new = new_project_path,
+  code = {
+    create_slides()
+  }
 )
 ```
 
@@ -86,7 +86,9 @@ Now two more files have been added to the `doc/` folder. The resulting file
 structure should look something like this:
 
 ```{r file-structure-with-doc, echo=FALSE, results="markup", comment=""}
-withr::with_dir(fs::path_temp(), {fs::dir_tree(basename(new_project_path))})
+withr::with_dir(fs::path_temp(), {
+  fs::dir_tree(basename(new_project_path))
+})
 ```
 
 At present, there are only two template files that you can view:


### PR DESCRIPTION

## Description

It isn't often ideal to have the project come with the Quarto report (especially in my teaching settings). So removing it from `project_setup()`.

Closes #132
